### PR TITLE
Broker id mapping

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func init() {
 
 	flag.StringVar(&flPrometheusURL, "prometheus-url", "", "Prometheus URL")
 	flag.DurationVar(&flPrometheusQueryTimeout, "prometheus-query-timeout", 30*time.Second, "Timeout for Prometheus queries")
-	flag.StringVar(&flZkAddr, "zk-addr", "localhost:2181", "Zookeeper host")
+	flag.StringVar(&flZkAddr, "zk-addr", "localhost:2181", "Zookeeper host, optional zkchroot after port. Eg. \"localhost:2181/my-chroot\"")
 	flag.StringVar(&flPartitionSizeQuery, "partition-size-query", "", "Prometheus query to get partition size by topic")
 	flag.StringVar(&flBrokerStorageQuery, "broker-storage-query", "", "Prometheus query to get broker storage free space")
 	flag.StringVar(&flBrokerIDLabel, "broker-id-label", "broker_id", "Prometheus label for broker ID")

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 	flPartitionSizeQuery     string
 	flBrokerStorageQuery     string
 	flBrokerIDLabel          string
+	flBrokerIDMap            map[string]string
 	flDryRun                 bool
 
 	zkChroot  string
@@ -61,6 +62,7 @@ func init() {
 	flag.StringVar(&flPartitionSizeQuery, "partition-size-query", "", "Prometheus query to get partition size by topic")
 	flag.StringVar(&flBrokerStorageQuery, "broker-storage-query", "", "Prometheus query to get broker storage free space")
 	flag.StringVar(&flBrokerIDLabel, "broker-id-label", "broker_id", "Prometheus label for broker ID")
+	flag.StringToStringVar(&flBrokerIDMap, "broker-id-map", nil, "Map value to broker ID. Eg.\"10.25.76.1=1004,10.53.32.1=1005\"")
 	flag.BoolVar(&flDryRun, "dry-run", false, "Fetch the metrics but don't write them to ZooKeeper, instead print them")
 	flag.Parse()
 }
@@ -96,9 +98,23 @@ func getBrokerFreeSpace() *brokerStorageFree {
 	if result.Type() == model.ValVector {
 		vectorVal := result.(model.Vector)
 
-		for _, elem := range vectorVal {
-			bid := string(elem.Metric[model.LabelName(flBrokerIDLabel)])
-			m[bid] = brokerStorageFreeValue{StorageFree: float64(elem.Value)}
+		if flBrokerIDMap != nil {
+			log.Infof("Broker ID Map: %v", flBrokerIDMap)
+			if len(vectorVal) != len(flBrokerIDMap) {
+				log.Warn("Returned metrics not equal to broker ID override map")
+			}
+			for _, elem := range vectorVal {
+				bid := string(elem.Metric[model.LabelName(flBrokerIDLabel)])
+				if k, exists := flBrokerIDMap[bid]; exists {
+					bid = k
+				}
+				m[bid] = brokerStorageFreeValue{StorageFree: float64(elem.Value)}
+			}
+		} else {
+			for _, elem := range vectorVal {
+				bid := string(elem.Metric[model.LabelName(flBrokerIDLabel)])
+				m[bid] = brokerStorageFreeValue{StorageFree: float64(elem.Value)}
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds a `--broker-id-map` `map[string]string` flag.

Allows us to map an arbitrary Prom label to a provided broker ID.

For example, if your metrics do not have a broker ID label, and instead
uses the 'instance' label with the IP address of the instance.
```
max(node_filesystem_avail{kafka_cluster="main",mountpoint="/rootfs/mnt/disks/sdf"}) by (instance)
```
Element | Value
-- | --
{instance="10.10.10.1"} | 505056583680
{instance="10.10.10.2"} | 695616950272


To solve this we could manually map the IP to the broker ID.
```
--broker-id-label=instance \
--broker-id-map='10.10.10.1=1001,10.10.10.2=1002'
```

Also clarified how to use zhchroot.