### PR TITLE
Fix: close gzip writer before writing gzip content to zookeeper

### DIFF
--- a/main.go
+++ b/main.go
@@ -270,18 +270,17 @@ func writeToZookeeper(zkConn *zk.Conn, path string, data []byte) error {
 		}
 	}
 
-    if flCompress {
-        var buf bytes.Buffer
-        zw := gzip.NewWriter(&buf)
-        defer zw.Close()
+	if flCompress {
+		var buf bytes.Buffer
+		zw := gzip.NewWriter(&buf)
 
-        _, err = zw.Write(data)
-        if err != nil {
-            return fmt.Errorf("unable to compress data")
-        }
-
-	    data = buf.Bytes()
-    }
+		_, err = zw.Write(data)
+		if err != nil {
+			return fmt.Errorf("unable to compress data")
+		}
+		zw.Close()
+		data = buf.Bytes()
+	}
 
 	// Create the data node
 	log.Printf("writing data to %s", path)


### PR DESCRIPTION
By using `defer zw.Close()`, we were closing the `gzip.Writer` _after_ the call to `zk.Create`, meaning we were only writing the gzip headers, and not the actual gzipped data.

Example (before)

```python
>>> zk.get('/topicmappr/partitionmeta')
(b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff', ZnodeStat(czxid=270583345356, mzxid=270583345356, ctime=1698148991659, mtime=1698148991659, version=0, cversion=0, aversion=0, ephemeralOwner=0, dataLength=10, numChildren=0, pzxid=270583345356))
>>> zk.get('/topicmappr/brokermetrics')
(b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff', ZnodeStat(czxid=270583345358, mzxid=270583345358, ctime=1698148991664, mtime=1698148991664, version=0, cversion=0, aversion=0, ephemeralOwner=0, dataLength=10, numChildren=0, pzxid=270583345358))
```

After

```python
>>> zk.get('/topicmappr/partitionmeta')
(b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xec}moxb0\xff\xfd\x82T\xb7-Q..., ZnodeStat(czxid=270583345404, mzxid=270583345404, ctime=1698150274536, mtime=1698150274536, version=0, cversion=0, aversion=0, ephemeralOwner=0, dataLength=12682, numChildren=0, pzxid=270583345404))
>>> zk.get('/topicmappr/brokermetrics')
(b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xffl\xcf\xbb\x8d\xc3@\x0c\x84\xe1^6\xbe\x80\xc3\xc7\x90\...\x00\x00', ZnodeStat(czxid=270583345406, mzxid=270583345406, ctime=1698150274540, mtime=1698150274540, version=0, cversion=0, aversion=0, ephemeralOwner=0, dataLength=157, numChildren=0, pzxid=270583345406))
```

I checked and with this fix, `topicmappr rebalance` is happy with the data, and computes a rebalance plan.

Sorry, my previous patches were obviously lacking in quality.